### PR TITLE
Перенёс ссылку на видеозаписи вебинаров

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Natch (Network Application Tainting Can Help) - это инструмент дл
 
 1. [Релизы](7_appendix.md#app_releases)
 
+Видеозаписи вебинаров по Natch располагаются [здесь](https://nextcloud.ispras.ru/index.php/s/natch_webinars).
 
 <br><br>
 


### PR DESCRIPTION
Ссылку передвинул.

По прежнему предлагаю убрать с главной страницы генерацию документации в формате PDF.

Это точно не настолько значимо для Натча, чтобы прямо на главную страницу вытаскивать. Предлагаю в FAQ отдельным пунктом "Как получить документацию в виде единого документа".
